### PR TITLE
Fixed 'NoAuth' error while broker connecting to ZooKeeper

### DIFF
--- a/config/sasl_ssl/zookeeper.properties
+++ b/config/sasl_ssl/zookeeper.properties
@@ -11,6 +11,10 @@ ssl.keyStore.location=PATH-TO-YOUR-KAFKA-DIR/ssl/kafka.zookeeper.keystore.jks
 ssl.keyStore.password=vinodks
 ssl.clientAuth=need
 
+# ACL check will be completely skipped by zookeeper,
+# but ZK will check the valid SSL certificate if it is configured in TLS mode.
+skipACL=yes
+
 # disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns=0
 


### PR DESCRIPTION
Fixed 'NoAuth' error while broker connecting to ZooKeeper